### PR TITLE
Fixes duplication of pattern sample markup

### DIFF
--- a/assets/js/pattern-library/markup-viewer.js
+++ b/assets/js/pattern-library/markup-viewer.js
@@ -1,9 +1,17 @@
 $(function() {
-	$('.pl-sub-pattern-markup').each(function(){
-		$(this).before('<div class="pl-sub-pattern-sample"><div class="pl-sub-pattern-sample-toggle-controls"><span class="show">&#43; Show HTML</span><span class="hide">&#45; Hide HTML</span></div><div class="pl-sub-pattern-sample-toggle-target"><pre class="language-handlebars"><code><script type="prism-html-markup">'+$(this).html()+'</script></code></pre></div></div>');
+
+	$('.pl-sub-pattern-markup').each(function(index){		
+			if (!$('#pattern-sample-' + index)[0]) {
+					$(this).before('<div id="pattern-sample-' + index + '" class="pl-sub-pattern-sample"><div class="pl-sub-pattern-sample-toggle-controls"><span class="show">&#43; Show HTML</span><span class="hide">&#45; Hide HTML</span></div><div class="pl-sub-pattern-sample-toggle-target"><pre class="language-handlebars"><code><script type="prism-html-markup">'+$(this).html()+'</script></code></pre></div></div>');
+			}
 	});
 
-	$('.pl-sub-pattern').on('click','.pl-sub-pattern-sample-toggle-controls', function(){
-		$(this).parent('.pl-sub-pattern-sample').toggleClass('visible');
+	$('.pl-sub-pattern').on('click','.show', function(){
+			$(this).parent().parent().addClass('visible');
 	});
+
+	$('.pl-sub-pattern').on('click','.hide', function(){
+			$(this).parent().parent().removeClass('visible');
+	});
+
 });


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes duplication of pattern sample markup.

Testing checklist:
- [x] I do not see a duplicate "show html" button for each pattern.
- [x] When I click the "show html" button, the pattern preview is visible.
- [x] When I click the "hide html" button, the pattern preview is hidden.

Fixes ushahidi/platform-pattern-library#135.

Ping @ushahidi/platform-pattern-library

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-pattern-library/136)
<!-- Reviewable:end -->
