### PR TITLE
Increased z-index to fix datepicker when filter modal open

### DIFF
--- a/assets/sass/utils/pickadate/base.scss
+++ b/assets/sass/utils/pickadate/base.scss
@@ -6,7 +6,7 @@
  */
 .picker {
   position: absolute;
-  z-index: 10000;
+  z-index: 100000;
   -webkit-user-select: none;
      -moz-user-select: none;
       -ms-user-select: none;


### PR DESCRIPTION
This pull request makes the following changes:
- Increases z-index to fix datepicker when the filter modal is open.

Testing checklist:
- [x] The datepicker is always above the filter modal so when I click outside the datepicker, the datepicker closes correctly.

Fixes ushahidi/platform#1803 (w/ ushahidi/platform-client#675).

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-pattern-library/137)
<!-- Reviewable:end -->
