### PR TITLE
Added flexbox to inline input to support loading button

### DIFF
--- a/assets/sass/1_basics/_forms.scss
+++ b/assets/sass/1_basics/_forms.scss
@@ -130,23 +130,36 @@ input[type="file"] {
 .input-inline { //for when a button is next to the input
     @include direction;
     clear: both;
+    @include media($small) {
+        display: flex;
+        margin: $sm-spacing auto;
+    }
 
     input {
-        display: inline;
-        @include margin-right($sm-spacing);
-        margin-bottom: $sm-spacing;
-        //width: 70%;
-
         @include media($small) {
-            width: 70%;
+            margin: auto !important;
+            margin-right: $sm-spacing !important;
+            max-width: 100%;
         }
     }
 
     button {
-        //height: 35px;
         @include lrswap(padding, 7px 15px 9px);
+        @include media($small) {
+            display: flex;
+            flex-wrap: nowrap;
+            height: 35px;
+            margin: auto !important;
+        }
+        
+        .loading {
+            @include media($small) {
+                display: flex;
+                justify-content: space-between;
+                width: 40px;
+            }
+        }
     }
-
 }
 
 input[type="checkbox"],


### PR DESCRIPTION
This pull request makes the following changes:
- Adds flex attributes to `inline-input` class
- Adds flex attributes to nested `loading` class to support flex inheritance

Testing checklist:
- [x] When I click a button and the button switches to a loading button (growing in width), the input field automatically adjusts to the size of the button

Fixes ushahidi/platform#1860 (w/ ushahidi/platform-client#688).

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-pattern-library/140)
<!-- Reviewable:end -->
