### PR TITLE
removing border from fieldset and fieldgroup entirely

### DIFF
--- a/assets/sass/2_fragments/_forms.scss
+++ b/assets/sass/2_fragments/_forms.scss
@@ -876,7 +876,6 @@ fieldset,
 
     .form-field &,
     fieldset & {
-        // @include border-left(2px solid $color-light-beta);
         @include padding-left($sm-spacing);
         margin-top: $sm-spacing;
         margin-bottom: $sm-spacing;


### PR DESCRIPTION
For some reason the comment was ignored (maybe its uglify playing tricks?) and the code adding the border was still there. This pr removes that line of code entirely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-pattern-library/143)
<!-- Reviewable:end -->
