### PR TITLE
Namespace RTL styles with a class

### DIFF
--- a/assets/js/pattern-library/rtl-class-toggle.js
+++ b/assets/js/pattern-library/rtl-class-toggle.js
@@ -1,9 +1,9 @@
-$('.rtl').click(function() {
-    $(this).addClass('active').siblings('.ltr').removeClass('active');
-    $('body').addClass('rtl');
+$('.rtl-switcher').click(function() {
+    $(this).addClass('active').siblings('.ltr-switcher').removeClass('active');
+    $('body').addClass('rtl').removeClass('ltr-namespace').addClass('rtl-namespace');
 });
 
-$('.ltr').click(function() {
-    $(this).addClass('active').siblings('.rtl').removeClass('active');
-    $('body').removeClass('rtl');
+$('.ltr-switcher').click(function() {
+    $(this).addClass('active').siblings('.rtl-switcher').removeClass('active');
+    $('body').removeClass('rtl').removeClass('rtl-namespace').addClass('ltr-namespace');
 });

--- a/assets/js/pattern-library/rtl-style-switcher.js
+++ b/assets/js/pattern-library/rtl-style-switcher.js
@@ -1,11 +1,11 @@
 $(document).ready(function() {
 
-    $('span.ltr').click(function() {
-    $('#stylesheet').attr({href : '../../css/style.css'});
+    $('span.ltr-switcher').click(function() {
+    //$('#stylesheet').attr({href : '../../css/style.css'});
     });
 
-    $('span.rtl').click(function() {
-    $('#stylesheet').attr({href : '../../css/rtl-style.css'});
+    $('span.rtl-switcher').click(function() {
+    //$('#stylesheet').attr({href : '../../css/rtl-style.css'});
     });
 
 });

--- a/assets/sass/0_pattern-library/_header.scss
+++ b/assets/sass/0_pattern-library/_header.scss
@@ -1,7 +1,7 @@
 /*------------------------------------*\
 $HEADER
 \*------------------------------------*/
-.pl {
+&.pl {
     background: $lt-gray;
     padding-bottom: $lg-spacing;
 }
@@ -61,9 +61,10 @@ $HEADER
         &:hover {
             opacity: 0.75;
         }
+
+        @if $rtl {
+            text-indent: 9999px;
+        }
     }
 
-    .rtl & .pl-thanks-logo {
-        text-indent: 9999px;
-    }
 }

--- a/assets/sass/0_pattern-library/_navigation.scss
+++ b/assets/sass/0_pattern-library/_navigation.scss
@@ -150,8 +150,8 @@ $NAVIGATION
             padding: 0 19px;
         }
 
-        .ltr,
-        .rtl {
+        .ltr-switcher,
+        .rtl-switcher {
             background: $color-primary-alpha;
             color: $white;
             margin: 0 0 0 10px;
@@ -170,8 +170,8 @@ $NAVIGATION
 
 .pl-read-direction-nav-layout {
 
-    .ltr,
-    .rtl {
+    .ltr-switcher,
+    .rtl-switcher {
         display: block;
         text-align: center;
         background: $color-primary-alpha;

--- a/assets/sass/0_pattern-library/_pattern-overrides.scss
+++ b/assets/sass/0_pattern-library/_pattern-overrides.scss
@@ -7,7 +7,7 @@ positioning, etc.)
 
 \*------------------------------------*/
 
-.pl {
+&.pl {
 
     &.modal-visible {
         overflow: auto;

--- a/assets/sass/1_basics/_progress-bar.scss
+++ b/assets/sass/1_basics/_progress-bar.scss
@@ -15,10 +15,10 @@
         background-size: 35px 20px, 100% 100%, 100% 100%;
         -webkit-animation: progress-animate 1s linear infinite;
         animation: progress-animate 1s linear infinite;
-    }
 
-    .rtl & > span {
-        text-indent: 9999px;
+        @if $rtl {
+            text-indent: 9999px;
+        }
     }
 }
 

--- a/assets/sass/3_modules/_postcard.scss
+++ b/assets/sass/3_modules/_postcard.scss
@@ -44,8 +44,10 @@
                 flex-shrink: 1;
             }
 
-            .rtl & .postcard-title {
-                order: 2;
+            @if $rtl {
+                .postcard-title {
+                    order: 2;
+                }
             }
 
             .postcard-actions {
@@ -76,8 +78,10 @@
             }
         }
 
-        .rtl & .postcard-header .metadata{
-            order: 2;
+        @if $rtl {
+            .postcard-header .metadata{
+                order: 2;
+            }
         }
     }
 

--- a/assets/sass/3_modules/_searchbar.scss
+++ b/assets/sass/3_modules/_searchbar.scss
@@ -9,7 +9,7 @@
     .searchbar-input {
         flex: 1;
 
-        .rtl & {
+        @if $rtl {
             order: 2;
         }
 

--- a/assets/sass/5_layouts/_layout-a.scss
+++ b/assets/sass/5_layouts/_layout-a.scss
@@ -1,4 +1,4 @@
-.layout-a {
+&.layout-a {
 
     [role="main"] {
         padding-top: 107px;

--- a/assets/sass/5_layouts/_layout-b.scss
+++ b/assets/sass/5_layouts/_layout-b.scss
@@ -1,4 +1,4 @@
-.layout-b {
+&.layout-b {
 
     [role="main"] {
         padding-top: 55px;

--- a/assets/sass/5_layouts/_layout-c.scss
+++ b/assets/sass/5_layouts/_layout-c.scss
@@ -1,4 +1,4 @@
-.layout-c {
+&.layout-c {
 
     [role="main"] {
         padding-top: 55px;

--- a/assets/sass/5_layouts/_layout-d.scss
+++ b/assets/sass/5_layouts/_layout-d.scss
@@ -1,4 +1,4 @@
-.layout-d {
+&.layout-d {
 
     [role="main"] {
         padding-top: 107px;

--- a/assets/sass/5_layouts/_layout-embed.scss
+++ b/assets/sass/5_layouts/_layout-embed.scss
@@ -1,4 +1,4 @@
-.layout-embed {
+&.layout-embed {
 
     .mode-context {
 

--- a/assets/sass/5_layouts/_layout-general.scss
+++ b/assets/sass/5_layouts/_layout-general.scss
@@ -11,7 +11,7 @@
     }
 }
 
-[class*="layout-"] {
+&[class*="layout-"] {
 
     .mode-bar {
         position: fixed;

--- a/assets/sass/_settings.scss
+++ b/assets/sass/_settings.scss
@@ -40,7 +40,7 @@ $xtall: new-breakpoint(min-height $xtall-min-height);
 $start: left; // start = beginning reading position
 $end: right; // end = end reading position
 
-body.rtl {
+body.rtl-namespace {
     $start: right;
     $end: left;
 

--- a/assets/sass/dependencies.scss
+++ b/assets/sass/dependencies.scss
@@ -1,0 +1,21 @@
+/*------------------------------------*\
+    $BOURBON & FRIENDS
+\*------------------------------------*/
+
+// Bourbon
+// imported via the gulp sass task includePath within gulpfile.js
+@import "bourbon";
+
+// Neat
+// imported via the gulp sass task includePath within gulpfile.js
+@import "neat";
+
+/*------------------------------------*\
+    $CONFIG
+\*------------------------------------*/
+@import "settings";
+
+/*------------------------------------*\
+    $UTILITIES
+\*------------------------------------*/
+@import "utils/mixins";

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -1,24 +1,6 @@
 /*------------------------------------*\
-    $BOURBON & FRIENDS
-\*------------------------------------*/
-
-// Bourbon
-// imported via the gulp sass task includePath within gulpfile.js
-@import "bourbon";
-
-// Neat
-// imported via the gulp sass task includePath within gulpfile.js
-@import "neat";
-
-/*------------------------------------*\
-    $CONFIG
-\*------------------------------------*/
-@import "settings";
-
-/*------------------------------------*\
     $UTILITIES
 \*------------------------------------*/
-@import "utils/mixins";
 @import "utils/helpers";
 
 /*------------------------------------*\

--- a/assets/sass/utils/rtl/ltr.scss
+++ b/assets/sass/utils/rtl/ltr.scss
@@ -5,5 +5,11 @@ $left: left;
 $right: right;
 
 @import "rtl-sass";
-@import "test";
-@import "../../style";
+@import "../../dependencies";
+// Hack: Include top level styles outside of namespace
+@import "../../1_basics/base";
+
+.ltr-namespace {
+	//@import "test";
+	@import "../../style";
+}

--- a/assets/sass/utils/rtl/rtl.scss
+++ b/assets/sass/utils/rtl/rtl.scss
@@ -5,5 +5,11 @@ $left: right;
 $right: left;
 
 @import "rtl-sass";
-@import "test";
-@import "../../style";
+@import "../../dependencies";
+// Hack: Include top level styles outside of namespace
+@import "../../1_basics/base";
+
+.rtl-namespace {
+	//@import "test";
+	@import "../../style";
+}

--- a/assets/templates/_ModeBar.hbs
+++ b/assets/templates/_ModeBar.hbs
@@ -46,8 +46,8 @@
                 </ul>
             </li>
             <li class="pl-read-direction-nav-layout">
-                <span class="ltr active">LTR</span>
-                <span class="rtl">RTL</span>
+                <span class="ltr-switcher active">LTR</span>
+                <span class="rtl-switcher">RTL</span>
             </li>
 
         </ul>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <link href="assets/css/style.css" rel="stylesheet" type="text/css" />
     </head>
 
-    <body class="pl">
+    <body class="pl ltr-namespace">
 
         <div class="wrapper">
 

--- a/pattern-library/1_basics/index.html
+++ b/pattern-library/1_basics/index.html
@@ -3,7 +3,7 @@
 
     @@include('../partials/_pl-head.html')
 
-    <body class="pl">
+    <body class="pl ltr-namespace">
 
         <div class="wrapper">
 

--- a/pattern-library/2_fragments/index.html
+++ b/pattern-library/2_fragments/index.html
@@ -9,7 +9,7 @@
 
     @@include('../partials/_pl-head.html')
 
-    <body class="pl">
+    <body class="pl ltr-namespace">
 
         <div class="wrapper">
 

--- a/pattern-library/3_modules/index.html
+++ b/pattern-library/3_modules/index.html
@@ -9,7 +9,7 @@
 
     @@include('../partials/_pl-head.html')
 
-    <body class="pl">
+    <body class="pl ltr-namespace">
 
         <div class="wrapper">
 

--- a/pattern-library/4_blocks/index.html
+++ b/pattern-library/4_blocks/index.html
@@ -9,7 +9,7 @@
 
     @@include('../partials/_pl-head.html')
 
-    <body class="pl">
+    <body class="pl ltr-namespace">
 
         <div class="wrapper">
 

--- a/pattern-library/5_layouts/account.html
+++ b/pattern-library/5_layouts/account.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.account.hbs' //-->
 

--- a/pattern-library/5_layouts/activity.html
+++ b/pattern-library/5_layouts/activity.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
     <!--// HTML markup for this layout is contained in '/assets/templates/layouts.activity.hbs' //-->
 

--- a/pattern-library/5_layouts/cloud-login.html
+++ b/pattern-library/5_layouts/cloud-login.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-e">
+<body class="layout-e ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.cloud-login.hbs' //-->
 

--- a/pattern-library/5_layouts/embed-map.html
+++ b/pattern-library/5_layouts/embed-map.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-embed">
+<body class="layout-embed ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.embed-map.hbs' //-->
 

--- a/pattern-library/5_layouts/index.html
+++ b/pattern-library/5_layouts/index.html
@@ -3,7 +3,7 @@
 
     @@include('../partials/_pl-head.html')
 
-    <body class="pl">
+    <body class="pl ltr-namespace">
 
         <div class="wrapper">
 

--- a/pattern-library/5_layouts/layout-a.html
+++ b/pattern-library/5_layouts/layout-a.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.layout-a.hbs' //-->
 

--- a/pattern-library/5_layouts/layout-b.html
+++ b/pattern-library/5_layouts/layout-b.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-b">
+<body class="layout-b ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.layout-b.hbs' //-->
 

--- a/pattern-library/5_layouts/layout-c.html
+++ b/pattern-library/5_layouts/layout-c.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-c">
+<body class="layout-c ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.layout-c.hbs' //-->
 

--- a/pattern-library/5_layouts/map-collection.html
+++ b/pattern-library/5_layouts/map-collection.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.map-collection.hbs' //-->
 

--- a/pattern-library/5_layouts/map-saved.html
+++ b/pattern-library/5_layouts/map-saved.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.map-saved.hbs' //-->
 

--- a/pattern-library/5_layouts/map.html
+++ b/pattern-library/5_layouts/map.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
     <!--// Deployment build: "Loading" screen
     <div class="tour-mask"></div>

--- a/pattern-library/5_layouts/post-add.html
+++ b/pattern-library/5_layouts/post-add.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-c">
+<body class="layout-c ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.post-add.hbs' //-->
 

--- a/pattern-library/5_layouts/post-detail.html
+++ b/pattern-library/5_layouts/post-detail.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-c">
+<body class="layout-c ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.post-detail.hbs' //-->
 

--- a/pattern-library/5_layouts/post-edit.html
+++ b/pattern-library/5_layouts/post-edit.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.post-edit.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-categories.html
+++ b/pattern-library/5_layouts/settings-categories.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-b">
+<body class="layout-b ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-categories.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-category-edit.html
+++ b/pattern-library/5_layouts/settings-category-edit.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-category-edit.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-datasources-email.html
+++ b/pattern-library/5_layouts/settings-datasources-email.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-datasources-email.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-datasources-twitter.html
+++ b/pattern-library/5_layouts/settings-datasources-twitter.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-datasources-twitter.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-datasources.html
+++ b/pattern-library/5_layouts/settings-datasources.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-c">
+<body class="layout-c ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-datasources.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-export.html
+++ b/pattern-library/5_layouts/settings-export.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-c">
+<body class="layout-c ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-export.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-general.html
+++ b/pattern-library/5_layouts/settings-general.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-general.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-import-complete.html
+++ b/pattern-library/5_layouts/settings-import-complete.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-c">
+<body class="layout-c ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-import-complete.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-import.html
+++ b/pattern-library/5_layouts/settings-import.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-c">
+<body class="layout-c ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-import.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-plans-manage.html
+++ b/pattern-library/5_layouts/settings-plans-manage.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-plans-manage.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-plans.html
+++ b/pattern-library/5_layouts/settings-plans.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-c">
+<body class="layout-c ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-plans.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-role-edit.html
+++ b/pattern-library/5_layouts/settings-role-edit.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-roles-edit.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-roles.html
+++ b/pattern-library/5_layouts/settings-roles.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-b">
+<body class="layout-b ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-roles.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-survey-edit.html
+++ b/pattern-library/5_layouts/settings-survey-edit.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-survey-edit.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-surveys.html
+++ b/pattern-library/5_layouts/settings-surveys.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-b">
+<body class="layout-b ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-surveys.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-tasks.html
+++ b/pattern-library/5_layouts/settings-tasks.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-c">
+<body class="layout-c ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-tasks.hbs' //-->
 

--- a/pattern-library/5_layouts/settings-users.html
+++ b/pattern-library/5_layouts/settings-users.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
    <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings-users.hbs' //-->
 

--- a/pattern-library/5_layouts/settings.html
+++ b/pattern-library/5_layouts/settings.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-c">
+<body class="layout-c ltr-namespace">
 
     <!--// HTML markup for this layout is contained in '/assets/templates/layouts.settings.hbs' //-->
 

--- a/pattern-library/5_layouts/tasks.html
+++ b/pattern-library/5_layouts/tasks.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
     <!--// HTML markup for this layout is contained in '/assets/templates/layouts.tasks.hbs' //-->
 

--- a/pattern-library/5_layouts/timeline.html
+++ b/pattern-library/5_layouts/timeline.html
@@ -3,7 +3,7 @@
 
 @@include('../partials/_pl-head.html')
 
-<body class="layout-a">
+<body class="layout-a ltr-namespace">
 
     <!--// HTML markup for this layout is contained in '/assets/templates/layouts.timeline.hbs' //-->
 

--- a/pattern-library/partials/_pl-head.html
+++ b/pattern-library/partials/_pl-head.html
@@ -11,5 +11,6 @@
     <!--<link href='http://fonts.googleapis.com/css?family=Lato:400,900,400italic,900italic' rel='stylesheet' type='text/css'>-->
     <link href='../../fonts/Lato/css/fonts.css' rel='stylesheet' type='text/css'>
     <link id="stylesheet" href="../../css/style.css" rel="stylesheet" type="text/css" />
+    <link id="stylesheet" href="../../css/rtl-style.css" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
 </head>

--- a/pattern-library/partials/_read-direction.html
+++ b/pattern-library/partials/_read-direction.html
@@ -1,5 +1,5 @@
 <div class="pl-read-direction-nav">
     <div class="pl-read-direction-wrapper">
-        <span>Read Direction: <span class="ltr active">LTR</span> <span class="rtl">RTL</span></span>
+        <span>Read Direction: <span class="ltr-switcher active">LTR</span> <span class="rtl-switcher">RTL</span></span>
     </div>
 </div>

--- a/rtl-test.html
+++ b/rtl-test.html
@@ -19,7 +19,7 @@
     <link href="assets/css/rtl-style.css" rel="alternate stylesheet" type="text/css" title="rtl" />
 </head>
 
-<body class="pl">
+<body class="pl ltr-namespace">
 
     <div class="wrapper">
 


### PR DESCRIPTION
- Namespace everything under a `-namespace` class
- Rename switcher classes to `ltr-switcher` and `rtl-switcher`
- Load both stylesheets at once
- Replace code that depended on `.rtl` class with `@if $rtl` conditions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-pattern-library/146)
<!-- Reviewable:end -->
