### PR TITLE
New full-width-load-button

### DIFF
--- a/assets/sass/1_basics/_buttons.scss
+++ b/assets/sass/1_basics/_buttons.scss
@@ -134,6 +134,9 @@ input[type="button"] {
     }
 
 }
+.button-full-width {
+  width: 100%;
+}
 
 .button-plain {
     font-weight: normal;

--- a/pattern-library/1_basics/index.html
+++ b/pattern-library/1_basics/index.html
@@ -318,34 +318,36 @@
         <button type="button" class="button button-gamma">Button Gamma</button>
                             </div>
                         </div>
+
                         <div class="pl-sub-pattern">
                             <h4 class="pl-h4">Full width</h4>
                             <div class="pl-sub-pattern-markup">
                                 <button type="button" class="button button-full-width">Button full width</button>
                             </div>
                         </div>
-                          <div class="pl-sub-pattern">
+
+                        <div class="pl-sub-pattern">
                             <h4 class="pl-h4">Full width + beta</h4>
-                            <p class="small">Example using full-width + another button-color</p>
                             <div class="pl-sub-pattern-markup">
                                 <button type="button" class="button button-full-width button-beta">Button full width+beta</button>
                             </div>
+                            <p class="small">Example using full-width + another button-color</p>
                         </div>
 
                         <div class="pl-sub-pattern">
                             <h4 class="pl-h4">Flat</h4>
-                            <p class="small">Deemphasize a button by making it look like a link while maintaining button behavior. The example below is a flattened "gamma" button, but any button style can be flattened using the class name "button-flat."</p>
                             <div class="pl-sub-pattern-markup">
         <button type="button" class="button button-gamma button-flat">Button Flat</button>
                             </div>
+                            <p class="small">Deemphasize a button by making it look like a link while maintaining button behavior. The example below is a flattened "gamma" button, but any button style can be flattened using the class name "button-flat."</p>
                         </div>
 
                         <div class="pl-sub-pattern">
                             <h4 class="pl-h4">Destructive</h4>
-                            <p class="small">Buttons that delete data should use the "destructive" treatment.</p>
                             <div class="pl-sub-pattern-markup">
         <button type="button" class="button-destructive">Button Destructive</button>
                             </div>
+                            <p class="small">Buttons that delete data should use the "destructive" treatment.</p>
                         </div>
                     </div>
                 </section>

--- a/pattern-library/1_basics/index.html
+++ b/pattern-library/1_basics/index.html
@@ -318,6 +318,19 @@
         <button type="button" class="button button-gamma">Button Gamma</button>
                             </div>
                         </div>
+                        <div class="pl-sub-pattern">
+                            <h4 class="pl-h4">Full width</h4>
+                            <div class="pl-sub-pattern-markup">
+                                <button type="button" class="button button-full-width">Button full width</button>
+                            </div>
+                        </div>
+                          <div class="pl-sub-pattern">
+                            <h4 class="pl-h4">Full width + beta</h4>
+                            <p class="small">Example using full-width + another button-color</p>
+                            <div class="pl-sub-pattern-markup">
+                                <button type="button" class="button button-full-width button-beta">Button full width+beta</button>
+                            </div>
+                        </div>
 
                         <div class="pl-sub-pattern">
                             <h4 class="pl-h4">Flat</h4>

--- a/pattern-library/2_fragments/index.html
+++ b/pattern-library/2_fragments/index.html
@@ -91,7 +91,32 @@
         </button>
                         </div>
                     </div>
-
+            <div class="pl-sub-pattern">
+                <h4 class="pl-h4">Full-width button, loading</h4>
+                <div class="pl-sub-pattern-markup">
+                    <button type="button" class="button button-full-width">
+                    <div class="loading">
+                        <div class="line"></div>
+                        <div class="line"></div>
+                        <div class="line"></div>
+                    </div>
+                    <span class="button-label">Loading</span>
+                    </button>
+                </div>
+            </div>
+            <div class="pl-sub-pattern">
+                <h4 class="pl-h4">Full-width button, beta, loading</h4>
+                <div class="pl-sub-pattern-markup">
+                    <button type="button" class="button button-full-width button-beta">
+                    <div class="loading">
+                        <div class="line"></div>
+                        <div class="line"></div>
+                        <div class="line"></div>
+                    </div>
+                    <span class="button-label">Loading</span>
+                    </button>
+                </div>
+            </div>
                     <div class="pl-sub-pattern">
                         <h4 class="pl-h4">Buttons Up/Down</h4>
                         <div class="pl-sub-pattern-markup">


### PR DESCRIPTION
This pr adds:
- a new, full-width-button and an example of full-width-button + beta-color.
- a new full-width-loading button in fragments + an example of full-width + beta-color.

Test by:
1. Go to basics and click on buttons.
2. You find the new buttons at "FULL WIDTH" and "FULL WIDTH + BETA"
3. Go to fragments and click on buttons.
4. You find the load-buttons at "FULL-WIDTH BUTTON, LOADING" and "FULL-WIDTH BUTTON, BETA, LOADING"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-pattern-library/149)
<!-- Reviewable:end -->
