### PR TITLE
Making the required asterisk same font-size

### DIFF
--- a/assets/sass/1_basics/_forms.scss
+++ b/assets/sass/1_basics/_forms.scss
@@ -25,7 +25,7 @@ label,
             top: -2px;
             color: $red;
             font-weight: normal;
-            font-size: 1.428571429em;
+            font-size: 1.05em;
             @include margin-left(4px);
         }
     }

--- a/assets/sass/1_basics/_icons.scss
+++ b/assets/sass/1_basics/_icons.scss
@@ -40,7 +40,7 @@ span.required:after {
     content: '\2217';
     color: #B00F23;
     font-weight: normal;
-    font-size: 1.75em;
+    font-size: 1.05em;
     @include margin-left(2px);
 }
 

--- a/assets/sass/2_fragments/_listing-item.scss
+++ b/assets/sass/2_fragments/_listing-item.scss
@@ -243,6 +243,8 @@
             &:after {
                 content: '\2217';
                 position: relative;
+                font-weight: normal;
+                font-size: 1.05em;
                 top: -4px;
                 color: $red;
                 @include margin-left(4px);


### PR DESCRIPTION
This pr adjusts the font-size and weight to appear the same all over the app. This fix a problem in the client with the asterisk not being the same size for different field-types (for example non fieldset and fieldset-types) in post-add and post-edit-views.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-pattern-library/157)
<!-- Reviewable:end -->
