### PR TITLE
fixing offset checkboxes

### DIFF
--- a/assets/sass/5_layouts/_layout-d.scss
+++ b/assets/sass/5_layouts/_layout-d.scss
@@ -13,7 +13,7 @@
         }
 
         input[type=checkbox] {
-            margin: 10px;
+            margin: 0px;
         }
 
         .toolbar {


### PR DESCRIPTION
This seems to fix checkbox styling issues for the following displayed checkboxes:
- filter menu: Sources
- filter menu: Categories
- filter menu: Status
- filter menu: Survey
- editing Post checkboxes

Fixes ushahidi/platform#2136 .


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-pattern-library/160)
<!-- Reviewable:end -->
