### PR TITLE
Filter dropdown fixes

### DIFF
--- a/assets/sass/4_blocks/_toolbar.scss
+++ b/assets/sass/4_blocks/_toolbar.scss
@@ -103,9 +103,29 @@
         }
 
         .dropdown-menu {
-
+            min-height: 100vh;
+            @include media($small) {
+                max-width: none;
+            }
             .dropdown-menu-body {
-                max-height: 300px;
+                min-height: 90vh;
+                max-height: 93vh !important;
+
+                @include media($medium-down) {
+                    min-height: 85vh;
+                    max-height: 85vh !important;
+
+                }
+
+                @include media($small-down) {
+                    min-height:60vh;
+                    max-height: 75vh !important;
+                }
+
+                 @include media($mobile-down) {
+                    min-height:60vh;
+                    max-height: 75vh !important;
+                }
             }
         }
 

--- a/assets/sass/4_blocks/_toolbar.scss
+++ b/assets/sass/4_blocks/_toolbar.scss
@@ -107,25 +107,55 @@
             @include media($small) {
                 max-width: none;
             }
+
             .dropdown-menu-body {
-                min-height: 90vh;
-                max-height: 93vh !important;
+                min-height: 100vh;
+                max-height: 100vh !important;
+                padding-bottom: 100px;
 
                 @include media($medium-down) {
-                    min-height: 85vh;
-                    max-height: 85vh !important;
-
+                    padding-bottom: 200px;
                 }
-
-                @include media($small-down) {
-                    min-height:60vh;
-                    max-height: 75vh !important;
+                @include media($medium-down) {
+                    padding-bottom: 250px;
                 }
+            }
 
-                 @include media($mobile-down) {
-                    min-height:60vh;
-                    max-height: 75vh !important;
-                }
+            .filter-actions {
+                position: absolute;
+                right: 0;
+                bottom: 36px;
+                left: 0;
+                margin: 16px 0 0 0 !important;
+                z-index: $body;
+                overflow: hidden;
+                border-top: 1px solid $color-light-gamma;
+                padding: $sm-spacing;
+
+                    @include media($medium-down) {
+                        bottom: 125px;
+                    }
+
+                    &:before {
+                        content: '';
+                        position: absolute;
+                        z-index: -1;
+                        top: 0;
+                        right: 0;
+                        bottom: 36px;
+                        left: 0;
+                        background-color: $color-light-gamma;
+                        -webkit-filter: blur(10px);
+                        -moz-filter: blur(10px);
+                        -o-filter: blur(10px);
+                        -ms-filter: blur(10px);
+                        filter: blur(10px);
+                        opacity: 0.8;
+                    }
+
+                    .form-field {
+                        margin: 0;
+                    }
             }
         }
 

--- a/assets/sass/5_layouts/_layout-d.scss
+++ b/assets/sass/5_layouts/_layout-d.scss
@@ -4,20 +4,7 @@
     @include media($medium) {
         overflow: hidden;
     }
- .filter-actions {
-    @include media($medium-down) {
-        bottom:73px !important;
-    }
-}
-    .dropdown-menu-body {
 
-                @include media($medium-down) {
-                    padding-bottom: 150px !important;
-                }
-                @include media($mobile-down) {
-                    padding-bottom: 200px !important;
-                }
-    }
     [role="main"] {
         @include padding-left(0);
 
@@ -284,5 +271,24 @@
         @include media($medium) {
             @include left(0);
         }
+    }
+
+    .dropdown-menu-body {
+
+        @include media($medium-down) {
+            padding-bottom: 150px;
+        }
+
+        @include media($mobile-down) {
+            padding-bottom: 200px;
+        }
+    }
+
+    .filter-actions {
+
+        @include media($medium-down) {
+            bottom:73px;
+        }
+
     }
 }

--- a/assets/sass/5_layouts/_layout-d.scss
+++ b/assets/sass/5_layouts/_layout-d.scss
@@ -4,7 +4,20 @@
     @include media($medium) {
         overflow: hidden;
     }
+ .filter-actions {
+    @include media($medium-down) {
+        bottom:73px !important;
+    }
+}
+    .dropdown-menu-body {
 
+                @include media($medium-down) {
+                    padding-bottom: 150px !important;
+                }
+                @include media($mobile-down) {
+                    padding-bottom: 200px !important;
+                }
+    }
     [role="main"] {
         @include padding-left(0);
 

--- a/assets/sass/5_layouts/_layout-d.scss
+++ b/assets/sass/5_layouts/_layout-d.scss
@@ -34,21 +34,17 @@
             }
 
             .searchbar {
-                width: 100%;
-
-                @include media($small) {
-                    width: 70%;
-                    @include padding-right(42px);
+                width: 50%;
+                @include media($small-down) {
+                    width: 100%;
                 }
 
                 @include media($large) {
                     width: 50%;
-                    @include padding-right(42px);
                 }
 
                 @include media($xxlarge) {
                     width: 35%;
-                    @include padding-right(122px);
                 }
             }
 

--- a/assets/templates/_Search-d.hbs
+++ b/assets/templates/_Search-d.hbs
@@ -226,10 +226,10 @@
                     </div>
                 </div>
             </fieldset>
-            <div class="form-field">
+        </div>
+        <div class="modal-actions">
                 <button type="button" class="button-link">Cancel</button>
                 <button type="button" class="button-alpha">Apply filters</button>
-            </div>
         </div>
     </div>
 </form>

--- a/assets/templates/_Search-d.hbs
+++ b/assets/templates/_Search-d.hbs
@@ -13,13 +13,6 @@
     </div>
 
     <div class="searchbar-options">
-        <a class="button">
-            <svg class="iconic">
-                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#star"></use>
-            </svg>
-            <span class="button-label hidden">Saved</span>
-        </a>
-
         <a href="#" class="button searchbar-options-filter" data-toggle="search-filters">
             <span class="button-label-d">
                 <span class="badge iconic">4</span>Sort & filter

--- a/assets/templates/_Search-d.hbs
+++ b/assets/templates/_Search-d.hbs
@@ -226,10 +226,12 @@
                     </div>
                 </div>
             </fieldset>
+
         </div>
-        <div class="modal-actions">
-                <button type="button" class="button-link">Cancel</button>
-                <button type="button" class="button-alpha">Apply filters</button>
+        <div class="form-field filter-actions">
+            <button type="button" class="button-link">Cancel</button>
+            <button type="button" class="button-alpha">Apply filters</button>
         </div>
     </div>
+
 </form>


### PR DESCRIPTION
This pr makes the following:
- adjusts the filter-dropdown to be the same width as the filter-bar
- adjusts the height of the filter-dropdown to match the height of the window
- removes the saved-searches star
- makes apply filters/cancel buttons to stick to bottom of the dropdown

have included adjustments to mobile/smaller windows

Fixes issues ushahidi/platform#2267 and ushahidi/platform#2268

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-pattern-library/162)
<!-- Reviewable:end -->
