### PR TITLE
Moving fab button in data-view

### DIFF
--- a/assets/sass/5_layouts/_layout-d.scss
+++ b/assets/sass/5_layouts/_layout-d.scss
@@ -33,6 +33,18 @@
                 margin-bottom: $base-spacing;
             }
 
+            .fab {
+                display: flex;
+                position: fixed;
+                right: $sm-spacing;
+                bottom: $sm-spacing;
+                top: unset;
+                left: unset;
+                @include media($medium-down) {
+                    bottom: $sm-spacing+45;
+                }
+            }
+
             .searchbar {
                 width: 100%;
 


### PR DESCRIPTION
This pr moves the fab-button to always be placed in the bottom-right corner in data view, not only for smaller screens.

Fixes issues ushahidi/platform#2266

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-pattern-library/163)
<!-- Reviewable:end -->
