### PR TITLE
Removing on state style

### DIFF
--- a/assets/sass/3_modules/_form-sheet.scss
+++ b/assets/sass/3_modules/_form-sheet.scss
@@ -225,12 +225,6 @@
         }
 
         &.focus {
-            @include containerCard;
-            box-shadow: 0 0 2px rgba(0,0,0,0.12),
-                0 2px 2px rgba(0,0,0,0.24),
-                0 0 16px rgba(255, 195, 52, 0.3);
-            padding: $sm-spacing;
-
             @include media($mobile-down) {
                 margin-right: 0;
                 @include margin-left(4px);
@@ -327,12 +321,6 @@
             }
 
             &.focus {
-                @include containerCard;
-                box-shadow: 0 0 2px rgba(0,0,0,0.12),
-                    0 2px 2px rgba(0,0,0,0.24),
-                    0 0 16px rgba(255, 195, 52, 0.3);
-                padding: $sm-spacing;
-
                 @include media($mobile-down) {
                     @include margin-right(0);
                     @include margin-left(4px);


### PR DESCRIPTION
This pr removes box-shadow and container-card to .focus on form-sheets. This was causing an unwanted box around the input-bars in the client (not visible in the pattern-library)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-pattern-library/165)
<!-- Reviewable:end -->
