### PR TITLE
Fixing rotation and font-sizes

### DIFF
--- a/assets/sass/utils/_mixins.scss
+++ b/assets/sass/utils/_mixins.scss
@@ -20,3 +20,4 @@
 @import "mixins/transform";
 @import "mixins/transition";
 @import "mixins/typography";
+@import "mixins/px-to-em";

--- a/assets/sass/utils/mixins/_px-to-em.scss
+++ b/assets/sass/utils/mixins/_px-to-em.scss
@@ -1,0 +1,16 @@
+// Convert pixels to ems
+// eg. for a relational value of 12px write em(12) when the parent is 16px
+// if the parent is another value say 24px write em(12, 24)
+
+  @debug 'here';
+$em-base: 16px !default;
+
+@function em($pxval, $base: $em-base) {
+  @if not unitless($pxval) {
+    $pxval: strip-unit($pxval);
+  }
+  @if not unitless($base) {
+    $base: strip-unit($base);
+  }
+  @return ($pxval / $base) * 1em;
+}

--- a/assets/sass/utils/mixins/_transform.scss
+++ b/assets/sass/utils/mixins/_transform.scss
@@ -8,7 +8,7 @@
 
 // Rotate
 @mixin rotate ($deg) {
-	@include transform(rotate(#{$deg}deg));
+	@include transform(rotate(#{$deg}));
 }
 
 // Scale


### PR DESCRIPTION
This pr...
- Adds a px-to-em-converter function. This is removed from bourbon 5.0 and up. We should probably  revisit and remove the use of the em()-function, but I solved it like this for now.
- Removes an extra addition of 'deg' from the rotate-function. Resulted in the output '135 degdeg' instead of '135 deg'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-pattern-library/181)
<!-- Reviewable:end -->
