### PR TITLE
Fix error-label-bug

### DIFF
--- a/assets/sass/2_fragments/_alerts.scss
+++ b/assets/sass/2_fragments/_alerts.scss
@@ -17,8 +17,6 @@
     }
 
     &.error {
-        @include float(left);
-        @include clear(left);
         border-color: $error-color;
         background-color: lighten( $error-color, 50% );
 

--- a/assets/sass/2_fragments/_alerts.scss
+++ b/assets/sass/2_fragments/_alerts.scss
@@ -17,6 +17,8 @@
     }
 
     &.error {
+        @include float(left);
+        @include clear(left);
         border-color: $error-color;
         background-color: lighten( $error-color, 50% );
 

--- a/assets/sass/2_fragments/_forms.scss
+++ b/assets/sass/2_fragments/_forms.scss
@@ -64,10 +64,6 @@ fieldset {
         margin-bottom: $sm-spacing;
     }
 
-    .alert {
-        margin: $tiny-spacing 0;
-    }
-
     .metadata {
         margin: $tiny-spacing 0;
     }
@@ -147,6 +143,7 @@ fieldset {
             @include clear(left);
             border-color: $error-color;
             box-shadow: 0 0 $tiny-spacing $error-color;
+            margin-bottom: $sm-spacing;
 
             &:focus {
                 border-color: $error-color;
@@ -158,6 +155,10 @@ fieldset {
             label {
                 color: $error-color;
             }
+        }
+
+        + .form-field {
+            clear: both;
         }
 
     }

--- a/assets/templates/layouts.data-edit.hbs
+++ b/assets/templates/layouts.data-edit.hbs
@@ -192,7 +192,18 @@
                     </a>
                 </li>
             </ul>
-
+            <div class="form-field init required error">
+                <label class="required" for="title">
+                    Title
+                </label>
+                <input id="title" name="title" type="text" required="required" />
+                <div class="alert error">
+                    <svg class="iconic">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#warning"></use>
+                    </svg>
+                    <span>A title is required</span>
+                </div>
+            </div>
             {{#each answers}}
                 {{formField ../properties.survey 0 @index value}}
             {{/each}}

--- a/assets/templates/layouts.post-add.hbs
+++ b/assets/templates/layouts.post-add.hbs
@@ -107,7 +107,18 @@
 
                 {{/if}}
             </ul>
-
+            <div class="form-field init required error">
+                <label class="required" for="title">
+                    Title
+                </label>
+                <input id="title" name="title" type="text" required="required" />
+                <div class="alert error">
+                    <svg class="iconic">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#warning"></use>
+                    </svg>
+                    <span>A title is required</span>
+                </div>
+            </div>
             {{#each fields}}
                 {{#ifCond type.control 'text'}}
                 <div class="form-field">

--- a/assets/templates/layouts.settings-general.hbs
+++ b/assets/templates/layouts.settings-general.hbs
@@ -35,9 +35,15 @@
     <div class="main-col">
 
         <div class="form-sheet">
-            <div class="form-field title">
-                <label class="hidden">Deployment name</label>
-                <input type="text" placeholder="Deployment name" value="{{deployment.name}}">
+            <div class="form-field title init required error">
+                <label class="hidden required">Deployment name</label>
+                <input type="text" placeholder="Deployment name" value="{{deployment.name}}" />
+                <div class="alert error">
+                    <svg class="iconic">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#warning"></use>
+                    </svg>
+                    <span>A title is required</span>
+                </div>
             </div>
 
             <div class="form-field">

--- a/pattern-library/4_blocks/index.html
+++ b/pattern-library/4_blocks/index.html
@@ -247,10 +247,10 @@
                                     <label class="required" for="title">
                                         Title
                                     </label>
-                                    <input id="title" name="title" type="text" required="required">
+                                    <input id="title" name="title" type="text" required="required" />
                                     <div class="alert error">
                                         <svg class="iconic">
-                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/44fed91f69f09c95876314a8e23f311e.svg#warning"></use>
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#warning"></use>
                                         </svg>
                                         <span>A title is required</span>
                                     </div>

--- a/pattern-library/4_blocks/index.html
+++ b/pattern-library/4_blocks/index.html
@@ -22,6 +22,7 @@
                     <li><a href="#pl-pattern-mode-bar">Mode Bar</a></li>
                     <li><a href="#pl-pattern-mode-context">Mode Context</a></li>
                     <li><a href="#pl-pattern-toolbar">Toolbar</a></li>
+                    <li><a href="#pl-pattern-survey">Add/edit survey</a></li>
                     <li><a href="#pl-pattern-map">Map</a></li>
                     <li><a href="#pl-pattern-mainsheet">Mainsheet</a></li>
                     <li><a href="#pl-pattern-modal">Modal</a></li>
@@ -201,6 +202,70 @@
                     </div>
                 </div>
             </section>
+    <section class="pl-pattern" id="pl-pattern-survey">
+        <div class="pl-pattern-description">
+            <h2>
+                Add/Edit survey
+            </h2>
+            <div class="pl-divider"></div>
+            </div>
+            <div class="container">
+                <div class="pl-sub-pattern">
+                    <h4 class="pl-h4">Add/edit a survey-form</h4>
+                        <div class="pl-sub-pattern-markup">
+                            <div class="form-sheet">
+                                <div class="post-band"></div>
+                                <div class="form-field">
+                                    <label class="required" for="title">
+                                        Title
+                                    </label>
+                                    <input id="title" name="title" type="text" required="required">
+                                    </div>
+                                     <div class="form-field">
+                                        <label class="required" for="content">
+                                            Description
+                                        </label>
+                                        <textarea id="content" name="content" data-min-rows="1" rows="1" required="required"></textarea>
+                                    </div>
+                            </div>
+                        </div>
+                </div>
+            </div>
+            <div class="pl-pattern-description">
+            <h2>
+                Add/Edit survey
+            </h2>
+            <div class="pl-divider"></div>
+            </div>
+            <div class="container">
+                <div class="pl-sub-pattern">
+                    <h4 class="pl-h4">Add/edit a survey-form, with error-message</h4>
+                        <div class="pl-sub-pattern-markup">
+                            <div class="form-sheet">
+                                <div class="post-band"></div>
+                                <div class="form-field init required error">
+                                    <label class="required" for="title">
+                                        Title
+                                    </label>
+                                    <input id="title" name="title" type="text" required="required">
+                                    <div class="alert error">
+                                        <svg class="iconic">
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/44fed91f69f09c95876314a8e23f311e.svg#warning"></use>
+                                        </svg>
+                                        <span>A title is required</span>
+                                    </div>
+                                </div>
+                                    <div class="form-field">
+                                        <label class="required" for="content">
+                                            Description
+                                        </label>
+                                        <textarea id="content" name="content" data-min-rows="1" rows="1" required="required"></textarea>
+                                    </div>
+                            </div>
+                        </div>
+                </div>
+            </div>
+    </section>
 
             <section class="pl-pattern" id="pl-pattern-map">
                 <div class="pl-pattern-description">


### PR DESCRIPTION
This pr:
- removes float:left for error-labels, which was causing the block below the label to move up beside it. 
- adds a form-block to "Blocks" with error-message-example and an example of error-message to post-add, post-edit and settings-general.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-pattern-library/186)
<!-- Reviewable:end -->
