### PR TITLE
1994-Fixes filter modal footer obscuring some elements

### DIFF
--- a/assets/sass/4_blocks/_toolbar.scss
+++ b/assets/sass/4_blocks/_toolbar.scss
@@ -27,7 +27,7 @@
             @include left($base-spacing);
             margin-top: -27px;
 
-            + .searchbar {
+            +.searchbar {
                 @include margin-left($base-spacing+54);
             }
         }
@@ -51,7 +51,7 @@
                     background-color: $color-primary-delta;
 
                     &::placeholder {
-                       color: $white;
+                        color: $white;
                     }
                 }
 
@@ -61,7 +61,7 @@
 
                         &:focus {
 
-                            + svg.iconic {
+                            +svg.iconic {
                                 fill: $color-primary-beta;
                             }
                         }
@@ -91,8 +91,8 @@
             }
         }
 
-        + .button-group,
-        + .fab + .button-group {
+        +.button-group,
+        +.fab+.button-group {
 
             // button,
             // .button {
@@ -104,6 +104,7 @@
 
         .dropdown-menu {
             min-height: 100vh;
+
             @include media($small) {
                 max-width: none;
             }
@@ -111,21 +112,28 @@
             .dropdown-menu-body {
                 min-height: 100vh;
                 max-height: 100vh !important;
-                padding-bottom: 100px;
+
+                &:after {
+                    content: '';
+                    display: block;
+                    padding-bottom: 100px;
+                }
 
                 @include media($medium-down) {
-                    padding-bottom: 200px;
+                    &:after {
+                        content: '';
+                        display: block;
+                        padding-bottom: 250px;
+                    }
                 }
-                @include media($medium-down) {
-                    padding-bottom: 250px;
-                }
-                .saved-search{
+
+                .saved-search {
 
                     &:before {
-                        content:'';
+                        content: '';
                         position: absolute;
                         top: $sm-spacing;
-                        bottom:15px;
+                        bottom: 15px;
                         left: -5px;
                         border-left: $base-border-dark;
                     }
@@ -136,7 +144,7 @@
                         margin-right: -13px;
 
                         &:before {
-                            content:'';
+                            content: '';
                             position: absolute;
                             width: 100%;
                             left: -22px;
@@ -159,30 +167,30 @@
                 border-top: 1px solid $color-light-gamma;
                 padding: $sm-spacing;
 
-                    @include media($medium-down) {
-                        bottom: 125px;
-                    }
+                @include media($medium-down) {
+                    bottom: 125px;
+                }
 
-                    &:before {
-                        content: '';
-                        position: absolute;
-                        z-index: -1;
-                        top: 0;
-                        right: 0;
-                        bottom: 36px;
-                        left: 0;
-                        background-color: $color-light-gamma;
-                        -webkit-filter: blur(10px);
-                        -moz-filter: blur(10px);
-                        -o-filter: blur(10px);
-                        -ms-filter: blur(10px);
-                        filter: blur(10px);
-                        opacity: 0.8;
-                    }
+                &:before {
+                    content: '';
+                    position: absolute;
+                    z-index: -1;
+                    top: 0;
+                    right: 0;
+                    bottom: 36px;
+                    left: 0;
+                    background-color: $color-light-gamma;
+                    -webkit-filter: blur(10px);
+                    -moz-filter: blur(10px);
+                    -o-filter: blur(10px);
+                    -ms-filter: blur(10px);
+                    filter: blur(10px);
+                    opacity: 0.8;
+                }
 
-                    .form-field {
-                        margin: 0;
-                    }
+                .form-field {
+                    margin: 0;
+                }
             }
         }
 
@@ -230,7 +238,7 @@
         &.error {
 
             svg.iconic {
-                stroke: rgba(255,255,255,0.8);
+                stroke: rgba(255, 255, 255, 0.8);
                 stroke-width: 0.5;
             }
         }
@@ -274,7 +282,7 @@
 
             svg.iconic {
 
-                + .button-label {
+                +.button-label {
 
                     @include media($mobile-down) {
                         display: none;

--- a/assets/sass/4_blocks/_toolbar.scss
+++ b/assets/sass/4_blocks/_toolbar.scss
@@ -116,14 +116,14 @@
                 &:after {
                     content: '';
                     display: block;
-                    padding-bottom: 100px;
+                    padding-bottom: 50px;
                 }
 
                 @include media($medium-down) {
                     &:after {
                         content: '';
                         display: block;
-                        padding-bottom: 250px;
+                        padding-bottom: 150px;
                     }
                 }
 


### PR DESCRIPTION
This pull request makes the following changes:
- A fix to filter modal footer obscuring some elements

The filter modal footer was obscuring some elements making it difficult to click or fill out input field. The elements were not visible in Firefox and Internet Explorer browsers.


Previous behaviour
![filter-modal-footer](https://user-images.githubusercontent.com/53520853/95947164-f2f8de00-0de5-11eb-88d2-f0a142d0268c.png)


Current behaviour with new styles
![Screenshot (78)](https://user-images.githubusercontent.com/53520853/95947322-3ce1c400-0de6-11eb-9a9f-9b56d4c0c39b.png)

Testing checklist:
I have tested with the new styles on the following browsers and it works perfectly;
- [x] Google Chrome
- [x] Firefox
- [x] Microsoft Edge
- [x] Internet Explorer
- [x] Safari
- [x] Opera

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#1994

Ping @ushahidi/platform