### PR TITLE
#3799-invisible-options-on-select

### DIFF
--- a/assets/sass/1_basics/_forms.scss
+++ b/assets/sass/1_basics/_forms.scss
@@ -300,6 +300,11 @@ select {
     select {
         -webkit-appearance: none;
         -moz-appearance: none;
+
+        option {
+            color: $color-dark-beta;
+            background-color: $white;
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes the [platform issue #3799](https://github.com/ushahidi/platform/issues/3799).

**Testing checklist**
- [ ] 1.  Add assets folder from [platform-pattern-library containing the new changes](https://github.com/ushahidi/platform-pattern-library/pull/245/commits) into platform-client as instructed in the documentation and run the project.
- [ ] 2. Go to Map tab.
- [ ] 3. Go to the bottom of the sidebar (screenshot attached) ![msedge_R1OvCOxrhF](https://user-images.githubusercontent.com/2558299/97197199-a5994b00-17ad-11eb-8233-507941d54a4a.png)
- [ ] 4. Click in the `Select Language` dropdown menu.
- [ ] 5. The displaying options should be visible, with a dark font and white background.
- [ ] 6. When an option is clicked, it replaces the text `Select Language` with the language selected. It should be a light font with a dark background.

Also,  if you don't mind... Can you label the PR as `hacktoberfest-accepted`? I'm also trying to do hacktoberfest this year :sweat_smile: 
