### PR TITLE
issue #4118 logo text resize

### DIFF
--- a/assets/sass/4_blocks/_mode-context.scss
+++ b/assets/sass/4_blocks/_mode-context.scss
@@ -381,6 +381,10 @@
 
                 .mode-context-title {
                     white-space: normal;
+
+                    a{
+                        font-size: large;
+                    }
                 }
             }
 

--- a/assets/sass/4_blocks/_mode-context.scss
+++ b/assets/sass/4_blocks/_mode-context.scss
@@ -383,7 +383,7 @@
                     white-space: normal;
 
                     a{
-                        font-size: large;
+                        word-break: break-word;
                     }
                 }
             }


### PR DESCRIPTION
This pull request makes the following changes:

- Added scss code for the font size of the logo on a larger screen.

Testing checklist:

- [ ] The logo which was breaking on large now looks perfect on all screen sizes.

- [x]  I certify that I ran my checklist

Fixes ushahidi/platform#4118.

Ping @ushahidi/platform

