### PR TITLE
Fix longs words no breaking in postcards layouts

### DIFF
--- a/assets/sass/3_modules/_postcard.scss
+++ b/assets/sass/3_modules/_postcard.scss
@@ -19,7 +19,7 @@
       @include margin-left(-30px);
 
     }
-    
+
     .listing-item-select {
         position: absolute;
         top: 15px;
@@ -201,6 +201,7 @@
         clear: both;
         line-height: 1.357142857;
         margin-bottom: $sm-spacing;
+        @include break-word;
 
         .form-label {
             display: none;


### PR DESCRIPTION
This PR fixes [the issue #2271 on platform](https://github.com/ushahidi/platform/issues/2271).

**Testing checklist**
- [ ] 1.  Add assets folder from [platform-pattern-library containing the new changes](https://github.com/ushahidi/platform-pattern-library/pull/249/commits) into platform-client as instructed in the documentation and run the project.
- [ ] 2. Log in to your account.
- [ ] 3. Go to Data tab.
- [ ] 4. Click on the yellow button with the `+` symbol in it.
- [ ] 5. Select which kind of post/survey you want to create (doesn't matter if we're testing)
- [ ] 6. A form would appear with text fields to fill. It's for creating a new post. ![msedge_4V8TIPKAHe](https://user-images.githubusercontent.com/2558299/97199189-075ab480-17b0-11eb-823f-c39b49539628.png)
- [ ] 7. Fill the `Title` field with a long word with more than 100 characters (you can make it up).
- [ ] 8. Click the upper right `Submit` button with the yellow background.
- [ ] 9. A new post appears where the word in the title breaks in multiple lines.

Also,  if you don't mind... Can you label the PR as `hacktoberfest-accepted`? I'm also trying to do hacktoberfest this year :sweat_smile: 