### PR TITLE
fix white text on chrome custom select drop down

### DIFF
--- a/assets/sass/4_blocks/_mode-context.scss
+++ b/assets/sass/4_blocks/_mode-context.scss
@@ -290,7 +290,14 @@
                     color: $white;
                     border-color: $color-primary-gamma;
                     background-color: transparent;
+
+                    option {
+                        color: $color-dark-beta;
+                        border-color: $color-primary-gamma;
+                        background-color: transparent;
+                    }
                 }
+
             }
 
             .dropdown-menu {


### PR DESCRIPTION

This pull request makes the following changes:
-

Testing checklist:
- [ x] open the application on chrome browser and the language  select dropdown now has visible select options

- [ x] I certify that I ran my checklist

Fixes ushahidi/platform#4106.

Ping @ushahidi/platform