### PR TITLE
#4119 - Fix focus for buttons in toolbar & for check boxes and radio

### DIFF
--- a/assets/sass/1_basics/_buttons.scss
+++ b/assets/sass/1_basics/_buttons.scss
@@ -46,7 +46,6 @@ input[type="button"] {
    &:focus {
        color: $white;
        outline: 2px solid $black;
-       outline: 5px auto -webkit-focus-ring-color;
        outline-offset: 2px;
 
    }

--- a/assets/sass/1_basics/_buttons.scss
+++ b/assets/sass/1_basics/_buttons.scss
@@ -45,6 +45,10 @@ input[type="button"] {
 
    &:focus {
        color: $white;
+       outline: 2px solid $black;
+       outline: 5px auto -webkit-focus-ring-color;
+       outline-offset: 2px;
+
    }
 
    &.disabled, &[disabled] {
@@ -229,13 +233,13 @@ a.button-fab {
         margin: 5px;
         text-transform: none;
         font-weight: 400;
-        
+
         &:first-child {
             margin-left: 0;
         }
 
         &:last-child {
-            margin-right: 0;    
+            margin-right: 0;
         }
 
         svg.iconic   {

--- a/assets/sass/1_basics/_forms.scss
+++ b/assets/sass/1_basics/_forms.scss
@@ -180,6 +180,13 @@ input[type="radio"] {
             color: $dk-gray;
         }
     }
+
+    &:focus {
+        outline: 2px solid $white;
+        box-shadow: 0 0 3px 5px $color-secondary,
+            inset 0 1px 1px rgba(0,0,0,.3);
+        border-color: $black;
+    }
 }
 
 //TODO: Revisit and clean up

--- a/assets/sass/1_basics/_forms.scss
+++ b/assets/sass/1_basics/_forms.scss
@@ -79,9 +79,9 @@ textarea {
     }
 
     &:focus {
-        box-shadow: 0 0 4px 1px $color-secondary,
+        outline: 2px solid $white;
+        box-shadow: 0 0 2px 4px $color-secondary,
             inset 0 1px 1px rgba(0,0,0,.3);
-        border-color: $black;
     }
 
     &[disabled] {
@@ -185,7 +185,6 @@ input[type="radio"] {
         outline: 2px solid $white;
         box-shadow: 0 0 3px 5px $color-secondary,
             inset 0 1px 1px rgba(0,0,0,.3);
-        border-color: $black;
     }
 }
 

--- a/assets/sass/4_blocks/_mode-context.scss
+++ b/assets/sass/4_blocks/_mode-context.scss
@@ -144,6 +144,7 @@
         background-color: $color-primary-alpha;
         @include box-shadow($top: 0, $left: -1px, $blur: 4px, $spread: 0, $color: rgba(30,35,42,1), $inset: false);
         padding: $sm-spacing+4 $sm-spacing;
+        margin: 3px;
 
         svg.iconic {
             fill: $color-tertiary;
@@ -155,6 +156,12 @@
             svg.iconic {
                 @include rotate(180deg);
             }
+        }
+
+        &:focus {
+            outline: 2px solid $white;
+            outline: 5px auto -webkit-focus-ring-color;
+            outline-offset: unset;
         }
     }
 

--- a/assets/sass/4_blocks/_mode-context.scss
+++ b/assets/sass/4_blocks/_mode-context.scss
@@ -160,7 +160,6 @@
 
         &:focus {
             outline: 2px solid $white;
-            outline: 5px auto -webkit-focus-ring-color;
             outline-offset: unset;
         }
     }

--- a/assets/sass/4_blocks/_toolbar.scss
+++ b/assets/sass/4_blocks/_toolbar.scss
@@ -25,7 +25,7 @@
 
     .button-fab {
         &:focus {
-            outline: none;
+            outline: 2px solid $color-dark-gamma;
             box-shadow: 1px 1px 5px $color-dark-gamma;
         }
     }

--- a/assets/sass/4_blocks/_toolbar.scss
+++ b/assets/sass/4_blocks/_toolbar.scss
@@ -17,6 +17,19 @@
         display: block;
     }
 
+    button {
+        &:focus {
+            outline: 2px solid $white;
+        }
+    }
+
+    .button-fab {
+        &:focus {
+            outline: none;
+            box-shadow: 1px 1px 5px $color-dark-gamma;
+        }
+    }
+
     .fab {
         display: none;
 

--- a/pattern-library/4_blocks/index.html
+++ b/pattern-library/4_blocks/index.html
@@ -100,12 +100,12 @@
 
                                 <div id="mode-context"></div>
 
-                                <span class="mode-context-trigger">
+                                <button class="mode-context-trigger">
                                     <svg class="iconic">
                                         <use xlink:href="../../img/iconic-sprite.svg#chevron-bottom"></use>
                                     </svg>
                                     <span class="label hidden">Show more/less</span>
-                                </span>
+                                </button>
 
                                 <div class="mode-context-body">
                                     <p>Reports and communication about the protest march Wednesday, Aug.19 to City Hall.</p>


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes ushahidi/platform#4119
(button focus aspect)

**Issues, observation & steps taken:**
- Focus is not defined for buttons in general on the site. Applied dark outline on focus to button element which favours buttons on white background e.g save search button, restore default and save & close buttons which are in the search filter dropdown. Done this way so that all other buttons on the site/platform will be focusable, outline color will only need to be changed like I have done in the case of the buttons found in the toolbar.
- The round yellow button with + sign (.button-fab) got a different styling on focus, because the background behind the button is halfway dark and halfway light for larger devices. Box-shadow is applied to make the button look pressed down and has a dark outline on focus. See [associated platform-client PR](https://github.com/ushahidi/platform-client/pull/1606).
- In smaller devices, span.mode-context-trigger is skipped. Changed it to button so that focus set for buttons can work on it and also so its role is clear to assistive technology like screen reader.
- It is not so obvious to the eyes when focus is on a particular checkbox or radio input. Added outline and increased box-shadow to make it catch the attention of user easily.

**Testing checklist:**
- [x] Add assets folder from platform-pattern-library containing the new changes made to the platform-client which also contains some new changes and run the project.
- [x] Login, and use tab key to navigate the toolbar on the map page.
- [x] Check that buttons are not skipped.
- [x] Check that the correct tab order is followed when navigating with the tab key.
- [x] Check that it is obvious to user that a button, checkbox and is in focus.

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
