### PR TITLE
#4119 - Improve focus for checkboxes, radio and input fields

### DIFF
--- a/assets/sass/1_basics/_forms.scss
+++ b/assets/sass/1_basics/_forms.scss
@@ -79,9 +79,9 @@ textarea {
     }
 
     &:focus {
-        box-shadow: 0 0 4px 1px $color-secondary,
+        outline: 2px solid $white;
+        box-shadow: 0 0 2px 4px $color-secondary,
             inset 0 1px 1px rgba(0,0,0,.3);
-        border-color: $black;
     }
 
     &[disabled] {
@@ -179,6 +179,12 @@ input[type="radio"] {
         + label {
             color: $dk-gray;
         }
+    }
+
+    &:focus {
+        outline: 2px solid $white;
+        box-shadow: 0 0 3px 5px $color-secondary,
+            inset 0 1px 1px rgba(0,0,0,.3);
     }
 }
 


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes ushahidi/platform#4119

**Issue, observation & steps taken:**
- It is not so obvious to the eyes when focus is on a particular checkbox, radio and input fields in general. Added outlineand increased the blur and spread of the box-shadow to give it an elevated look and make it catch the attention of user easily. See [associated platform-client PR](https://github.com/ushahidi/platform-client/pull/1606).

**Testing checklist:**
- [x] Add assets folder from platform-pattern-library containing the new changes made to the platform-client which also contains some new changes and run the project.
- [x] Login, navigate the search filter & the map page) using the tab key.
- [x] Check that the checkboxes, radio buttons and input fields in general are more noticable on focus (general problem all over the site).

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
