### PR TITLE
#4119 - fix focus and for buttons and skipped elements

### DIFF
--- a/assets/sass/1_basics/_buttons.scss
+++ b/assets/sass/1_basics/_buttons.scss
@@ -6,7 +6,7 @@ button,
 .button,
 input[type="button"] {
    display: inline-block;
-   outline: none;
+   outline-offset: 1px;
    @include direction;
    color: $white;
    font-weight: 800;
@@ -229,13 +229,13 @@ a.button-fab {
         margin: 5px;
         text-transform: none;
         font-weight: 400;
-        
+
         &:first-child {
             margin-left: 0;
         }
 
         &:last-child {
-            margin-right: 0;    
+            margin-right: 0;
         }
 
         svg.iconic   {

--- a/pattern-library/4_blocks/index.html
+++ b/pattern-library/4_blocks/index.html
@@ -100,12 +100,12 @@
 
                                 <div id="mode-context"></div>
 
-                                <span class="mode-context-trigger">
+                                <button class="mode-context-trigger">
                                     <svg class="iconic">
                                         <use xlink:href="../../img/iconic-sprite.svg#chevron-bottom"></use>
                                     </svg>
                                     <span class="label hidden">Show more/less</span>
-                                </span>
+                                </button>
 
                                 <div class="mode-context-body">
                                     <p>Reports and communication about the protest march Wednesday, Aug.19 to City Hall.</p>


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes ushahidi/platform#4119

**Issues, observation & steps taken:**
- Button elements are not focusable. Removed the outline set to none. See [associated platform-client PR](https://github.com/ushahidi/platform-client/pull/1606).
- In smaller devices, span.mode-context-trigger is skipped. Changed it to button so that focus set for buttons can work on it and also so its role is clear to assistive technology like screen reader.

**Testing checklist:**
- [x] Add assets folder from platform-pattern-library containing the new changes made to the platform-client which also contains some new changes and run the project.
- [x] Login, and use tab key to navigate the toolbar on the map page.
- [x] Check that buttons are not skipped and in correct order.
- [x] Check that it is obvious to user that a button is in focus.

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
