### PR TITLE
Fix 2746: Add 'skip to content' styles

### DIFF
--- a/assets/sass/4_blocks/_skip-to-content.scss
+++ b/assets/sass/4_blocks/_skip-to-content.scss
@@ -1,0 +1,18 @@
+.skip-to-content {
+    position: absolute;
+    top: -20px;
+    z-index: 0;
+    overflow: hidden;
+
+    &:focus,
+    &:active {
+        top: 0px;
+        font-size: 20px;
+        text-decoration: underline;
+        padding: 6px;
+        border-radius: 0px 0px 5px 5px;
+        background: #fff;
+        z-index: 4444;
+        width: 150px;
+    }
+}

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -89,6 +89,7 @@ structure of the pattern library
 @import "4_blocks/mode-bar";
 @import "4_blocks/mode-bar-dash";
 @import "4_blocks/mode-context";
+@import "4_blocks/skip-to-content";
 @import "4_blocks/toolbar";
 @import "4_blocks/upgrade-modal";
 /*------------------------------------*\

--- a/package-lock.json
+++ b/package-lock.json
@@ -1794,7 +1794,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1815,12 +1816,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1835,17 +1838,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1962,7 +1968,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1974,6 +1981,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1988,6 +1996,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1995,12 +2004,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2019,6 +2030,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2099,7 +2111,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2111,6 +2124,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2196,7 +2210,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2232,6 +2247,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2251,6 +2267,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2294,12 +2311,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
## Description of Issue
Screen readers tend to announce all of the links on the page to the user, in order to help with accessibility to bypass parts of each page, for example, navigation links in the mode-bar, filter-bar in the toolbar and get to main content, skip to content is needed.
Skip to content styles provides help with the positioning of the skip to content link, adding visibility, font properties, border properties.

## Proposed Solution
Skip to content styles is implemented in the upper left corner that says “Skip to Content.”, It is hidden and then brings into view when it is focused or active. It's the first thing that appears after the page is being loaded and tabbed on, it skips to the first postcard which is the most important of the page on the data view. it is only visible when tabbed on importantly for screen-readers only and hiding the skip-to-content link to everybody else.

## Testing
The testing was done manually by tabbing on the page which in turn activates the skip to content button as shown in the screenshot section below. The gulp test command was run to make sure no test is broken/affected by the changes.

## Testing checklist
- [x] I certify that I ran my checklist

### Post views

 - [ ] Go to data posts
 - [ ] Tab on page
 - [ ] "Skip to content" will be visible on top left side
 - [ ] Tab on "skip to content" button
 - [ ] Focus is on "skip to content" link
 - [ ] Press tab or space bar
 - [ ] Focus is on first post card

## Screenshots

|  Current        |    Proposed changes    |
| --------- |:----------:|
|     ![skip-to-content-pp](https://user-images.githubusercontent.com/66112760/97112118-cf397000-16e2-11eb-9523-d63182bb59d1.gif)         |   ![add-skip-to-content-pp](https://user-images.githubusercontent.com/66112760/97810088-9d3f8500-1c71-11eb-8292-b06a1d2fe9da.gif) |


Fixes ushahidi/platform#2746

Ping @ushahidi/platform @Angamanga @rowasc 
