### PR TITLE
#4133 Add visually-hidden helper class

### DIFF
--- a/assets/sass/utils/_helpers.scss
+++ b/assets/sass/utils/_helpers.scss
@@ -73,6 +73,16 @@ $LAYOUT
     display: none !important;
 }
 
+.visually-hidden:not(:focus):not(:active) {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
 .hide-when-mobile {
     display: inline-block;
     position: relative;


### PR DESCRIPTION
**This PR makes the following changes:**
- Fixes https://github.com/ushahidi/platform/issues/4133
- Adds visually-hidden class to _helpers.scss file.

**Usage:**

Class, when applied, hides an element with text content from view, at the same time it allows for content to be accessible when using screen reader.