### PR TITLE
Added button-filter class to support  the buttons in navigational menu

### DIFF
--- a/assets/sass/1_basics/_buttons.scss
+++ b/assets/sass/1_basics/_buttons.scss
@@ -306,4 +306,14 @@ a.button-fab {
     &:focus {
         color: $color-primary;
     }
+    &:hover {
+        color: $white;
+        svg.iconic {
+            fill: $white;
+        }
+    }
+    svg.iconic {
+        fill: $color-dark-alpha;
+        top: 11px;
+    }
 }

--- a/assets/sass/1_basics/_buttons.scss
+++ b/assets/sass/1_basics/_buttons.scss
@@ -293,3 +293,17 @@ a.button-fab {
    }
 
 }
+
+.button-filter {
+    color: $color-primary;
+    font-weight: 400;
+    text-align: initial;
+    text-transform: none;
+    background: none;
+    width: 100%;
+    box-shadow: none;
+    letter-spacing: 0px;
+    &:focus {
+        color: $color-primary;
+    }
+}


### PR DESCRIPTION
This pull request makes the following changes:
- It defines a class(button-filter) to support the dropdown buttons in the navigational menu present at /views/maps

Testing checklist:
- [ ] Open /views/maps.
- [ ] Disconnect your mouse and navigate with keyboard only.
- [ ] The buttons present next to the posts and data sources filter would be accessible along with its content.

- [x] I certify that I ran my checklist

Recording:
![Maps navbar](https://user-images.githubusercontent.com/70752431/103913090-2bcaf980-512e-11eb-9890-82c7c3b53bd6.gif)

Fixes ushahidi/platform#4187 .

Ping @ushahidi/platform
