### PR TITLE
Add button-export class to support export filtered data

### DIFF
--- a/assets/sass/1_basics/_buttons.scss
+++ b/assets/sass/1_basics/_buttons.scss
@@ -317,3 +317,24 @@ a.button-fab {
         top: 11px;
     }
 }
+
+.button-export {
+    color: $color-primary;
+    font-weight: 600;
+    text-align: initial;
+    text-transform: none;
+    background: none;
+    width: 100%;
+    box-shadow: none;
+    letter-spacing: 0px;
+    font-size: 1.142857143rem;
+    padding: 0;
+    &:focus {
+        color: $color-primary;
+    }
+    &:hover {
+        box-shadow: none;
+        background: none;
+        color: $color-primary;
+    }
+}


### PR DESCRIPTION
This pull request makes the following changes:
- It defines a class(button-export) to support the export filtered data option present in share menu

Testing checklist:
- [ ] Open /views/maps.
- [ ] Disconnect your mouse and navigate with keyboard only.
- [ ] Go to the share menu and press enter
- [ ] The export filtered data shall be accessible with keyboard

- [x] I certify that I ran my checklist

Recording:

![Export filtered data](https://user-images.githubusercontent.com/70752431/105353139-deae5380-5c14-11eb-8935-9243970b9346.gif)

