### PR TITLE
Added close button in mainsheet-window

### DIFF
--- a/assets/sass/4_blocks/_mainsheet.scss
+++ b/assets/sass/4_blocks/_mainsheet.scss
@@ -7,6 +7,17 @@
         .listing {
             border-top: 2px solid $color-light-gamma;
         }
+
+        .mainsheet-trigger-close {
+            position: absolute;
+            top: $base-spacing;
+            @include right($sm-spacing);
+            margin-top: -$tiny-spacing;
+    
+            @include media($mobile) {
+                @include right($base-spacing);
+            }
+        }
     }
 
     .mainsheet-heading {


### PR DESCRIPTION
This pull request makes the following changes:
- It creates a class for close button in mainsheet.

Testing checklist:
- [x] Go to /views/map.
- [x] Click on the add post button.
- [x] The mainsheet container is accessible via keyboard.

- [x] I certify that I ran my checklist

Recording:
![add_post_menu](https://user-images.githubusercontent.com/70752431/105681465-297ee280-5f17-11eb-9bd0-6bf4ecc0f530.gif)


Fixes ushahidi/platform#4188 .

Ping @ushahidi/platform
