### PR TITLE
Add class for button in tab order of account settings

### DIFF
--- a/assets/sass/3_modules/_tabs.scss
+++ b/assets/sass/3_modules/_tabs.scss
@@ -35,10 +35,47 @@
                 }
             }
 
+            .tab-button {
+                display: inline-block;
+                color: $color-primary-epsilon;
+                padding: $sm-spacing $base-spacing;
+                font-weight: 400;
+                text-transform: none;
+                background: none;
+                box-shadow: none;
+                letter-spacing: 0px;
+
+                svg.iconic {
+                    fill: $color-primary-epsilon;
+                    position: relative;
+                    top: 2px;
+                    @include margin-right(4px);
+                }
+
+                &:hover {
+                    color: $color-primary;
+                    box-shadow: none;
+                    background: none;
+                    svg.iconic {
+                        fill: $color-primary;
+                    }
+                }
+            }
+
             &.active {
 
                 a {
                     color: $color-primary-alpha;
+                    border-bottom: 2px solid $color-secondary;
+
+                    svg.iconic {
+                        fill: $color-primary-alpha;
+                    }
+                }
+
+                .tab-button {
+                    color: $color-primary-alpha;
+                    opacity: 1;
                     border-bottom: 2px solid $color-secondary;
 
                     svg.iconic {


### PR DESCRIPTION
This pull request adds a class for the tab buttons present in account settings to make them accessible.

Screenshot: 
![image](https://user-images.githubusercontent.com/70752431/106241676-6fe08400-622c-11eb-8ea3-849b2c942159.png)


Fixes ushahidi/platform#4194