### PR TITLE
Focus on switch

### DIFF
--- a/assets/sass/1_basics/_forms.scss
+++ b/assets/sass/1_basics/_forms.scss
@@ -377,10 +377,17 @@ form, .form {
         width: 100%;
         max-width: 100%;
     }
-}
+    }
 
-.tgl {//http://codepen.io/mallendeo/pen/eLIiG
-    display: none !important;
+    .tgl {//http://codepen.io/mallendeo/pen/eLIiG
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        height: 1px;
+        overflow: hidden;
+        position: absolute;
+        white-space: nowrap;
+        width: 1px;
+
     // add default box-sizing for this scope
     &, &:after, &:before,
     & *, & *:after, & *:before,
@@ -459,6 +466,10 @@ form, .form {
 
         }
     }
+
+    &:focus+.tgl-btn {
+       outline-color: transparent;
+       box-shadow: 0 0 3px 5px $color-secondary, inset 0 1px 1px rgba(0,0,0,.3);      }
 
 }
 

--- a/pattern-library/2_fragments/index.html
+++ b/pattern-library/2_fragments/index.html
@@ -123,6 +123,18 @@
                             </button>
                         </div>
                     </div>
+                    <div class="pl-sub-pattern">
+                        <h4 class="pl-h4">Toggle switch</h4>
+                        <div class="pl-sub-pattern-markup">
+                            <div class="form-field switch">
+                                <label>Include this field in filters</label>
+                                <div class="toggle-switch">
+                                    <input class="tgl visually-hidden" id="switch2" type="checkbox">
+                                    <label class="tgl-btn" for="switch2"></label>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
 
                     <div class="pl-sub-pattern">
                         <h4 class="pl-h4">Buttons Up/Down</h4>


### PR DESCRIPTION
This PR:
- Add focus-styles to toggle-switch
- Visually hides input-box in toggle-switch
- Adds toggle-switch to fragments-section

Testing checklist:
- Go to /assets/html/2_fragments/#pl-pattern-buttons
- Tab down to "TOGGLE SWITCH"
- Focus the switch via keyboard
- [ ] It should receive focus
- Press space
- [ ] It should switch