### PR TITLE
fix misaligned checkboxes

### DIFF
--- a/assets/sass/2_fragments/_listing-item.scss
+++ b/assets/sass/2_fragments/_listing-item.scss
@@ -12,7 +12,8 @@
         position: absolute;
         top: 50%;
         transform: translateY(-50%);
-        @include left($huge-spacing);
+        left: 30px;
+        bottom: 5px;
         z-index: $body;
 
         .buttons-updown {
@@ -22,7 +23,8 @@
         }
 
         + .listing-item-primary {
-            @include padding-left(46px);
+            @include padding-left(50px);
+            bottom: 8px;
 
             .listing-item-image {
                 @include left(46px);


### PR DESCRIPTION
This PR fixes the issue where checkboxes are overlapping their corresponding text. This PR aligns the checkboxes better but may not be a complete fix as the bottom checkbox is still slightly misaligned. This can serve as a patch and I will add a better fix to this as time permits.

Fixes [4241](https://github.com/ushahidi/platform/issues/4241) && [4229](https://github.com/ushahidi/platform/issues/4229)

## Current
![Screen Shot 2021-11-03 at 3 27 19 PM](https://user-images.githubusercontent.com/20748598/140187576-99a4ce62-b051-4dc6-b48e-bee9594c65b1.png)

## With Patch
![Screen Shot 2021-11-03 at 3 19 05 PM](https://user-images.githubusercontent.com/20748598/140187615-769a1f2c-0631-4379-90de-62a2245916c5.png)


